### PR TITLE
Update index.js: Wrong colour codes in donut chart

### DIFF
--- a/src/Summary/index.js
+++ b/src/Summary/index.js
@@ -104,7 +104,7 @@ const Summary = (props) => {
                 withActiveSegment={!isMobile}
                 withTooltip={isMobile}
                 donutWidth={60}
-                colors={['primary', 'success', 'alert']}
+                colors={['primary', 'alert', 'success']}
               />
             ) : (
               <div className="Spinner-container h-100">


### PR DESCRIPTION
The array of data is defined as "Active, Deaths & Recovered" in this order, so the array of coloraturas codes of donut chart is not defined in the same order. 

Resolved the above issue

Before:
<img width="1295" alt="Screenshot 2020-05-07 at 2 31 32 PM" src="https://user-images.githubusercontent.com/23071741/81275535-73fdbd80-906f-11ea-9ab6-dc73f95ae985.png">

After:
<img width="1295" alt="Screenshot 2020-05-07 at 2 32 38 PM" src="https://user-images.githubusercontent.com/23071741/81275669-9abbf400-906f-11ea-8225-5bffdf42672c.png">



